### PR TITLE
Remove scenic from recommended Gemfile entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Sqlite adapter for [scenic](https://github.com/thoughtbot/scenic).
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem 'scenic'
 gem 'scenic_sqlite_adapter'
 ```
 


### PR DESCRIPTION
This gem has a dependency on `scenic` so specifying `scenic_sqlite_adapter` as a dependency will take care of this. It will also avoid any potential versioning conflicts if some future version of scenic becomes incompatible with this gem. This gem can update its `scenic` dependency in the gemspec to specify compatible versions.